### PR TITLE
Use Git Plumbing Commands Wherever Possible

### DIFF
--- a/bash-scripts/check-git-status.sh
+++ b/bash-scripts/check-git-status.sh
@@ -38,7 +38,7 @@ checkParams () {
 
 # Check we're in a git repository, and there's no uncommitted changes 
 checkGitStatus() {
-	gitstatus=$(git status -z 2>&1)
+	gitstatus=$(git status --porcelain 2>&1)
 	while IFS= read -r
 	do
 		# Check we're in a git repo


### PR DESCRIPTION
Relying on Git porcelain commands is unstable as the output of these commands may change throughout versions; however, Git plumbing commands are very stable as they rarely change. Therefore, Git plumbing commands are recommended for use in scripting.

Although `git status -z` will call the porcelain command (`git status --porcelain`) by default, it is best to rely on the porcelain command directly (`git status --porcelain`).

Output stays exactly the same.

[More info on Git plumbing vs. porcelain commands.](https://git-scm.com/book/en/v2/Git-Internals-Plumbing-and-Porcelain)
